### PR TITLE
add billing to service_map.go

### DIFF
--- a/pkg/console/service_map.go
+++ b/pkg/console/service_map.go
@@ -6,6 +6,7 @@ var ServiceMap = map[string]string{
 	"":               "console",
 	"athena":         "athena",
 	"appsync":        "appsync",
+	"billing":        "billing",
 	"c9":             "cloud9",
 	"ce":             "cost-management",
 	"cf":             "cloudfront",


### PR DESCRIPTION
### What changed?
I added billing to the service map

### Why?
to get rid of this message
```[!] We don't recognize service billing but we'll try and open it anyway (you may receive a 404 page)```

### How did you test it?


### Potential risks


### Is patch release candidate?


### Link to relevant docs PRs